### PR TITLE
Change sale badge color to green

### DIFF
--- a/catalog.js
+++ b/catalog.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           badge.textContent = 'SOLD';
         } else if (lamp.status === 'sale') {
           badge.textContent = 'SALE';
-          badge.style.background = '#f60';
+          badge.style.background = '#4CAF50';
         }
         card.appendChild(badge);
       }


### PR DESCRIPTION
## Summary
- adjust sale badge styling to use a green background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b42fda590832e96b9655fda86bcf0