### PR TITLE
Add Netlify identity widget to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -125,6 +125,7 @@
             }
         }
     </style>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body class="desktop-view about-page">
     <header>

--- a/catalog.html
+++ b/catalog.html
@@ -6,6 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Catalogue - Lespwi Dacou</title>
 <link rel="stylesheet" href="style.css" />
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body class="desktop-view">
 <header>

--- a/contact.html
+++ b/contact.html
@@ -118,6 +118,7 @@
             }
         }
     </style>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body class="desktop-view">
     <header>

--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
 
 
     </style>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
     <!-- Desktop and Mobile (Unified Navigation) -->


### PR DESCRIPTION
## Summary
- include Netlify Identity widget script in every page to enable login modal

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b467e6724832ea17fb51e72251392